### PR TITLE
Fix: Prevent redirect to cart after successful order

### DIFF
--- a/src/pages/CheckoutPage.tsx
+++ b/src/pages/CheckoutPage.tsx
@@ -31,6 +31,7 @@ const CheckoutPage = () => {
   const { deliveryLat, deliveryLng, deliveryLocationName } = useLocationStore()
 
   // Form states
+  const [orderJustPlaced, setOrderJustPlaced] = useState(false);
   const [customerName, setCustomerName] = useState('')
   const [customerPhone, setCustomerPhone] = useState('')
   const [selectedDeliveryOption, setSelectedDeliveryOption] = useState('')
@@ -47,8 +48,8 @@ const CheckoutPage = () => {
   const [optionsError, setOptionsError] = useState<string | null>(null)
 
   useEffect(() => {
-    // Redirect if no items or location
-    if (items.length === 0) {
+    // Redirect if no items or location, and order was not just placed
+    if (items.length === 0 && !orderJustPlaced) { // MODIFIED LINE
       navigate('/cart')
       return
     }
@@ -65,7 +66,7 @@ const CheckoutPage = () => {
     }
     
     fetchInitialData()
-  }, [items.length, deliveryLat, deliveryLng, user, profile, navigate])
+  }, [items.length, deliveryLat, deliveryLng, user, profile, navigate, orderJustPlaced]) // ADD orderJustPlaced to dependencies
 
   useEffect(() => {
     // Calculate delivery charge for instant delivery
@@ -228,6 +229,7 @@ const CheckoutPage = () => {
       // Success: clear cart and navigate to success page
       console.log('Order placed successfully:', response.data)
       clearCart()
+      setOrderJustPlaced(true); // ADD THIS LINE
       navigate(`/order-confirmation/success/${response.data.order_id}`)
 
     } catch (error: any) {


### PR DESCRIPTION
Previously, after a successful order placement, you were navigated to the OrderSuccessPage but then immediately redirected to the CartPage.

This was caused by a useEffect in CheckoutPage.tsx that listens for changes in cart items. When clearCart() was called before navigating to the success page, this effect would trigger and redirect to /cart because the cart was now empty.

This commit introduces a state flag `orderJustPlaced` in CheckoutPage.tsx.
- This flag is set to true immediately before navigating to the OrderSuccessPage.
- The useEffect that redirects to /cart if the cart is empty now checks this flag and will not redirect if an order was just placed.

This ensures you remain on the OrderSuccessPage after a successful order, while still maintaining the original functionality of redirecting to /cart if the checkout page is accessed directly with an empty cart.